### PR TITLE
Bugfix for Avatto ZWT198 _TZE204_xnbkhhdr, fix reversed 6-1 and 5-2 in 'working_day' datapoint

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -6553,10 +6553,10 @@ const definitions: DefinitionWithExtend[] = [
                     'working_day',
                     tuya.valueConverterBasic.lookup((_, device) => {
                         // https://github.com/Koenkk/zigbee2mqtt/issues/23979
-                        if (device.manufacturerName === '_TZE204_lzriup1j') {
-                            return {disabled: tuya.enum(0), '6-1': tuya.enum(2), '5-2': tuya.enum(1), '7': tuya.enum(3)};
+                         if (device.manufacturerName === '_TZE200_viy9ihs7') {
+                            return { disabled: tuya.enum(0), '6-1': tuya.enum(1), '5-2': tuya.enum(2), '7': tuya.enum(3) };
                         } else {
-                            return {disabled: tuya.enum(0), '6-1': tuya.enum(1), '5-2': tuya.enum(2), '7': tuya.enum(3)};
+                            return { disabled: tuya.enum(0), '6-1': tuya.enum(2), '5-2': tuya.enum(1), '7': tuya.enum(3) };
                         }
                     }),
                 ],


### PR DESCRIPTION
Problem: the 6-1 and 5-2 option is reserved with _TZE204_xnbkhhdr.

Fix the reserved working_day options for Avatto (Tuya) ZWT198 _TZE204_xnbkhhdr. It use the same method as _TZE204_lzriup1j.